### PR TITLE
chore: replace deprecated template-lib

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -271,7 +271,7 @@ steps:
         from_secret: matrix_password
       roomid:
         from_secret: matrix_roomid
-      template: "Status: **{{ build.Status }}**<br/> Build: [{{ repo.Owner }}/{{ repo.Name }}]({{ build.Link }}){{#if build.Branch}} ({{ build.Branch }}){{/if}} by {{ commit.Author }}<br/> Message: {{ commit.Message.Title }}"
+      template: "Status: **{{ .Build.Status }}**<br/> Build: [{{ .Repo.Owner }}/{{ .Repo.Name }}]({{ .Build.Link }}){{#if .Build.Branch}} ({{ .Build.Branch }}){{/if}} by {{ .Commit.Author }}<br/> Message: {{ .Commit.Message.Title }}"
       username:
         from_secret: matrix_username
     when:
@@ -292,6 +292,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 23c3365c3e827c02c0c57ab6d98e5bca2780471061b7976dad14578982404ad8
+hmac: a7e5de7ca26b5fa95bab02bf1e4cfe390ec90da4683e4f80244cfdce33c0d9a4
 
 ...

--- a/_docs/data/data.yaml
+++ b/_docs/data/data.yaml
@@ -32,7 +32,9 @@ properties:
     required: false
 
   - name: template
-    description: Golang template for the messages.
-    defaultValue: build {{ build.status }} [{{ repo.owner }}/{{ repo.name }}#{{ truncate build.commit 8 }}]({{ build.link }}) ({{ build.branch }}) by {{ build.author }}
+    description: |
+      Golang template for the message. The [pipeline struct](https://pkg.go.dev/github.com/thegeeklab/drone-plugin-lib/v2/drone#Pipeline)
+      is exposed to the template and all fields can be referenced. To extend the functionality, [sprig functions](https://masterminds.github.io/sprig/) can also be used.
+    defaultValue: "Build {{ .Build.Status }} [{{ .Repo.Owner }}/{{ .Repo.Name }}#{{ trunc 8 .Commit.SHA }}]({{ .Build.Link }}) ({{ .Build.Branch }}) by {{ .Commit.Author }}"
     type: string
     required: false

--- a/cmd/drone-matrix/config.go
+++ b/cmd/drone-matrix/config.go
@@ -62,7 +62,7 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			EnvVars: []string{"PLUGIN_TEMPLATE", "MATRIX_TEMPLATE"},
 			Usage:   "message template",
 			//nolint:lll
-			Value:       "Build {{ build.Status }} [{{ repo.Owner }}/{{ repo.Name }}#{{ truncate commit.SHA 8 }}]({{ build.Link }}) ({{ build.Branch }}) by {{ commit.Author }}",
+			Value:       "Build {{ .Build.Status }} [{{ .Repo.Owner }}/{{ .Repo.Name }}#{{ trunc 8 .Commit.SHA }}]({{ .Build.Link }}) ({{ .Build.Branch }}) by {{ .Commit.Author }}",
 			Destination: &settings.Template,
 			Category:    category,
 		},


### PR DESCRIPTION
BREAKING CHANGE: The new template helper provided by https://github.com/thegeeklab/drone-plugin-lib/pull/28 is using pure Golang templates and sprig templates. As the unmaintained Golang handlebar library was removed entirely, the template syntax has changed and custom templates need to be adjusted. For more details, please read the [documentation](https://drone-plugin-index.geekdocs.de/plugins/drone-matrix/#parameters).  